### PR TITLE
Remove empty instruction

### DIFF
--- a/client.c
+++ b/client.c
@@ -29,7 +29,7 @@ typedef enum {
 
 typedef struct {
     MessageType msg_type;
-    int value;;
+    int value;
     int port;
     int next_port;
 } Token;


### PR DESCRIPTION
## Motivation

Although modern compilers will compile-out this empty instruction, I believe it is a best practice to avoid it.

## Test plan

Run unit tests as usual. No evidence of changed behavior should be observed.

## List of changes

- removed empty instruction